### PR TITLE
add support for different data sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,18 @@ set(XVEGA_HEADERS
     ${XVEGA_INCLUDE_DIR}/xvega/functions/populate_marks.hpp
     ${XVEGA_INCLUDE_DIR}/xvega/functions/populate_encodings.hpp
     ${XVEGA_INCLUDE_DIR}/xvega/functions/populate_selections.hpp
+    ${XVEGA_INCLUDE_DIR}/xvega/grammar/data/data_format.hpp
+    ${XVEGA_INCLUDE_DIR}/xvega/grammar/data/data_format/json_data_format.hpp
+    ${XVEGA_INCLUDE_DIR}/xvega/grammar/data/data_format/csv_data_format.hpp
+    ${XVEGA_INCLUDE_DIR}/xvega/grammar/data/data_format/tsv_data_format.hpp
+    ${XVEGA_INCLUDE_DIR}/xvega/grammar/data/data_format/dsv_data_format.hpp
+    ${XVEGA_INCLUDE_DIR}/xvega/grammar/data/data_format/topo_data_format.hpp
+    ${XVEGA_INCLUDE_DIR}/xvega/grammar/data/data_source/named_data.hpp
+    ${XVEGA_INCLUDE_DIR}/xvega/grammar/data/data_source/url_data.hpp
+    ${XVEGA_INCLUDE_DIR}/xvega/grammar/data/data_source/inline_data.hpp
+    ${XVEGA_INCLUDE_DIR}/xvega/grammar/data/generator/sequence_generator.hpp
+    ${XVEGA_INCLUDE_DIR}/xvega/grammar/data/generator/sphere_generator.hpp
+    ${XVEGA_INCLUDE_DIR}/xvega/grammar/data/generator/graticule_generator.hpp
 )
 
 set(XVEGA_SOURCES
@@ -224,6 +236,17 @@ set(XVEGA_SOURCES
     ${XVEGA_SOURCE_DIR}/grammar/selections/selection_single.cpp
     ${XVEGA_SOURCE_DIR}/grammar/selections/selection_multi.cpp
     ${XVEGA_SOURCE_DIR}/grammar/selections/selection_interval.cpp
+    ${XVEGA_SOURCE_DIR}/grammar/data/data_format/json_data_format.cpp
+    ${XVEGA_SOURCE_DIR}/grammar/data/data_format/csv_data_format.cpp
+    ${XVEGA_SOURCE_DIR}/grammar/data/data_format/tsv_data_format.cpp
+    ${XVEGA_SOURCE_DIR}/grammar/data/data_format/dsv_data_format.cpp
+    ${XVEGA_SOURCE_DIR}/grammar/data/data_format/topo_data_format.cpp
+    ${XVEGA_SOURCE_DIR}/grammar/data/data_source/named_data.cpp
+    ${XVEGA_SOURCE_DIR}/grammar/data/data_source/url_data.cpp
+    ${XVEGA_SOURCE_DIR}/grammar/data/data_source/inline_data.cpp
+    ${XVEGA_SOURCE_DIR}/grammar/data/generator/sequence_generator.cpp
+    ${XVEGA_SOURCE_DIR}/grammar/data/generator/sphere_generator.cpp
+    ${XVEGA_SOURCE_DIR}/grammar/data/generator/graticule_generator.cpp
 )
 
 add_library(xvega SHARED ${XVEGA_SOURCES} ${XVEGA_HEADERS})

--- a/include/xvega/base/xvega-base.hpp
+++ b/include/xvega/base/xvega-base.hpp
@@ -35,10 +35,31 @@
 #include "../grammar/selections/selection_multi.hpp"
 #include "../grammar/selections/selection_interval.hpp"
 
+#include "../grammar/data/data_source/named_data.hpp"
+#include "../grammar/data/data_source/inline_data.hpp"
+#include "../grammar/data/data_source/url_data.hpp"
+#include "../grammar/data/generator/sequence_generator.hpp"
+#include "../grammar/data/generator/sphere_generator.hpp"
+#include "../grammar/data/generator/graticule_generator.hpp"
+
 namespace nl = nlohmann;
 
 namespace xv
 {
+    using data_source = xtl::variant<
+                             named_data, 
+                             inline_data,
+                             url_data
+                             >;
+
+    using generator = xtl::variant<
+                           sequence_generator, 
+                           sphere_generator,
+                           graticule_generator
+                           >;
+
+    using data_type = xtl::variant<data_source, generator, data_frame>;
+
     using marks_type = xtl::variant<
                             mark_arc, 
                             mark_area, 
@@ -66,7 +87,7 @@ namespace xv
 
     struct Chart : public xp::xobserved<Chart>
     {
-        XPROPERTY(data_frame, Chart, data);
+        XPROPERTY(data_type, Chart, data);
         XPROPERTY(std::vector<marks_type>, Chart, marks);
         XPROPERTY(std::vector<Encodings>, Chart, encodings);
         XPROPERTY(std::vector<selection_type>, Chart, selections); // matrix

--- a/include/xvega/grammar/data/data_format.hpp
+++ b/include/xvega/grammar/data/data_format.hpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef XVEGA_DATA_FORMAT_HPP
+#define XVEGA_DATA_FORMAT_HPP
+
+#include "../../xvega_config.hpp"
+#include "xproperty/xobserved.hpp"
+#include "../../utils/xeither.hpp"
+#include "../../utils/custom_datatypes.hpp"
+#include "../../utils/serialize.hpp"
+
+namespace xv
+{
+    using object_none_type = xtl::variant<std::nullptr_t, nl::json>;
+
+    template<class D>
+    struct data_format : public xp::xobserved<D>
+    {
+        XPROPERTY(xtl::xoptional<std::string>, D, type);
+        XPROPERTY(xtl::xoptional<object_none_type>, D, parse);
+
+        void to_json(nl::json& j) const
+        {
+            serialize(j, type(), "type");
+            serialize(j, parse(), "parse");
+        }
+
+        protected:
+            data_format() = default;
+            ~data_format() = default;
+
+            data_format(const data_format&) = default;
+            data_format& operator=(const data_format&) = default;
+
+            data_format(data_format&&) = default;
+            data_format& operator=(data_format&&) = default;
+    };
+
+    template<class D>
+    void to_json(nl::json& j, const data_format<D>& data)
+    {
+        data.derived_cast().to_json(j);
+    }
+}
+
+#endif

--- a/include/xvega/grammar/data/data_format/csv_data_format.hpp
+++ b/include/xvega/grammar/data/data_format/csv_data_format.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef XVEGA_CSV_DATA_FORMAT_HPP
+#define XVEGA_CSV_DATA_FORMAT_HPP
+
+#include "../data_format.hpp"
+
+namespace xv
+{
+    struct csv_data_format : public data_format<csv_data_format>
+    {
+        using base_type = data_format<csv_data_format>;
+
+        csv_data_format();
+
+        void to_json(nl::json& j) const;
+    };
+}
+
+#endif

--- a/include/xvega/grammar/data/data_format/dsv_data_format.hpp
+++ b/include/xvega/grammar/data/data_format/dsv_data_format.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef XVEGA_DSV_DATA_FORMAT_HPP
+#define XVEGA_DSV_DATA_FORMAT_HPP
+
+#include "../data_format.hpp"
+
+namespace xv
+{
+    struct dsv_data_format : public data_format<dsv_data_format>
+    {
+        using base_type = data_format<dsv_data_format>;
+
+        XPROPERTY(xtl::xoptional<std::string>, dsv_data_format, delimiter);
+
+        dsv_data_format();
+
+        void to_json(nl::json& j) const;
+    };
+}
+
+#endif

--- a/include/xvega/grammar/data/data_format/json_data_format.hpp
+++ b/include/xvega/grammar/data/data_format/json_data_format.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef XVEGA_JSON_DATA_FORMAT_HPP
+#define XVEGA_JSON_DATA_FORMAT_HPP
+
+#include "../data_format.hpp"
+
+namespace xv
+{
+    struct json_data_format : public data_format<json_data_format>
+    {
+        using base_type = data_format<json_data_format>;
+
+        XPROPERTY(xtl::xoptional<std::string>, json_data_format, property);
+
+        json_data_format();
+
+        void to_json(nl::json& j) const;
+    };
+}
+
+#endif

--- a/include/xvega/grammar/data/data_format/topo_data_format.hpp
+++ b/include/xvega/grammar/data/data_format/topo_data_format.hpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef XVEGA_TOPO_DATA_FORMAT_HPP
+#define XVEGA_TOPO_DATA_FORMAT_HPP
+
+#include "../data_format.hpp"
+
+namespace xv
+{
+    struct topo_data_format : public data_format<topo_data_format>
+    {
+        using base_type = data_format<topo_data_format>;
+
+        XPROPERTY(xtl::xoptional<std::string>, topo_data_format, feature);
+        XPROPERTY(xtl::xoptional<std::string>, topo_data_format, mesh);
+
+        topo_data_format();
+
+        void to_json(nl::json& j) const;
+    };
+}
+
+#endif

--- a/include/xvega/grammar/data/data_format/tsv_data_format.hpp
+++ b/include/xvega/grammar/data/data_format/tsv_data_format.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef XVEGA_TSV_DATA_FORMAT_HPP
+#define XVEGA_TSV_DATA_FORMAT_HPP
+
+#include "../data_format.hpp"
+
+namespace xv
+{
+    struct tsv_data_format : public data_format<tsv_data_format>
+    {
+        using base_type = data_format<tsv_data_format>;
+
+        tsv_data_format();
+
+        void to_json(nl::json& j) const;
+    };
+}
+
+#endif

--- a/include/xvega/grammar/data/data_source/inline_data.hpp
+++ b/include/xvega/grammar/data/data_source/inline_data.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef XVEGA_INLINE_DATA_HPP
+#define XVEGA_INLINE_DATA_HPP
+
+#include "../data_format/csv_data_format.hpp"
+#include "../data_format/tsv_data_format.hpp"
+#include "../data_format/dsv_data_format.hpp"
+#include "../data_format/json_data_format.hpp"
+#include "../data_format/topo_data_format.hpp"
+
+namespace xv
+{
+    using data_format_type = xtl::variant<
+                                  csv_data_format, 
+                                  tsv_data_format, 
+                                  dsv_data_format, 
+                                  json_data_format, 
+                                  topo_data_format
+                                  >;
+
+    using inline_data_type = xtl::variant<
+                                  std::vector<std::string>,
+                                  std::vector<int>, 
+                                  std::vector<double>,
+                                  std::vector<bool>,
+                                  std::vector<nl::json>,
+                                  std::string,
+                                  nl::json
+                                  >;
+
+    struct inline_data : public xp::xobserved<inline_data>
+    {
+        XPROPERTY(inline_data_type, inline_data, values);
+        XPROPERTY(xtl::xoptional<std::string>, inline_data, name);
+        XPROPERTY(xtl::xoptional<data_format_type>, inline_data, format);
+    };
+
+    void to_json(nl::json& j, const inline_data& data);
+}
+
+#endif

--- a/include/xvega/grammar/data/data_source/named_data.hpp
+++ b/include/xvega/grammar/data/data_source/named_data.hpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef XVEGA_NAMED_DATA_HPP
+#define XVEGA_NAMED_DATA_HPP
+
+#include "../data_format/csv_data_format.hpp"
+#include "../data_format/tsv_data_format.hpp"
+#include "../data_format/dsv_data_format.hpp"
+#include "../data_format/json_data_format.hpp"
+#include "../data_format/topo_data_format.hpp"
+
+namespace xv
+{
+    using data_format_type = xtl::variant<
+                                  csv_data_format, 
+                                  tsv_data_format, 
+                                  dsv_data_format, 
+                                  json_data_format, 
+                                  topo_data_format
+                                  >;
+
+    struct named_data : public xp::xobserved<named_data>
+    {
+        XPROPERTY(xtl::xoptional<std::string>, named_data, name);
+        XPROPERTY(xtl::xoptional<data_format_type>, named_data, format);
+    };
+
+    void to_json(nl::json& j, const named_data& data);
+}
+
+#endif

--- a/include/xvega/grammar/data/data_source/url_data.hpp
+++ b/include/xvega/grammar/data/data_source/url_data.hpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef XVEGA_URL_DATA_HPP
+#define XVEGA_URL_DATA_HPP
+
+#include "../data_format/csv_data_format.hpp"
+#include "../data_format/tsv_data_format.hpp"
+#include "../data_format/dsv_data_format.hpp"
+#include "../data_format/json_data_format.hpp"
+#include "../data_format/topo_data_format.hpp"
+
+namespace xv
+{
+    using data_format_type = xtl::variant<
+                                  csv_data_format, 
+                                  tsv_data_format, 
+                                  dsv_data_format, 
+                                  json_data_format, 
+                                  topo_data_format
+                                  >;
+
+    struct url_data : public xp::xobserved<url_data>
+    {
+        XPROPERTY(xtl::xoptional<std::string>, url_data, url);
+        XPROPERTY(xtl::xoptional<std::string>, url_data, name);
+        XPROPERTY(xtl::xoptional<data_format_type>, url_data, format);
+    };
+
+    void to_json(nl::json& j, const url_data& data);
+}
+
+#endif

--- a/include/xvega/grammar/data/generator/graticule_generator.hpp
+++ b/include/xvega/grammar/data/generator/graticule_generator.hpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef XVEGA_GRATICULE_GENERATOR_HPP
+#define XVEGA_GRATICULE_GENERATOR_HPP
+
+#include "xproperty/xobserved.hpp"
+#include "xtl/xvariant.hpp"
+#include "xtl/xoptional.hpp"
+#include "nlohmann/json.hpp"
+#include "xtl/xjson.hpp"
+
+#include "../../../xvega_config.hpp"
+#include "../../../utils/serialize.hpp"
+
+namespace nl = nlohmann;
+
+namespace xv
+{
+    struct graticule_params : public xp::xobserved<graticule_params>
+    {
+        XPROPERTY(xtl::xoptional<std::vector<double>>, graticule_params, extent);
+        XPROPERTY(xtl::xoptional<std::vector<double>>, graticule_params, extentMajor);
+        XPROPERTY(xtl::xoptional<std::vector<double>>, graticule_params, extentMinor);
+        XPROPERTY(xtl::xoptional<double>, graticule_params, precision);
+        XPROPERTY(xtl::xoptional<std::vector<double>>, graticule_params, step);
+        XPROPERTY(xtl::xoptional<std::vector<double>>, graticule_params, stepMajor);
+        XPROPERTY(xtl::xoptional<std::vector<double>>, graticule_params, stepMinor);
+    };
+
+    void to_json(nl::json& j, const graticule_params& data);
+
+    using graticule_type = xtl::variant<bool, graticule_params>;
+
+    struct graticule_generator : public xp::xobserved<graticule_generator>
+    {
+        XPROPERTY(xtl::xoptional<graticule_type>, graticule_generator, graticule);
+        XPROPERTY(xtl::xoptional<std::string>, graticule_generator, name);
+    };
+
+    void to_json(nl::json& j, const graticule_generator& data);
+}
+
+#endif

--- a/include/xvega/grammar/data/generator/sequence_generator.hpp
+++ b/include/xvega/grammar/data/generator/sequence_generator.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef XVEGA_SEQUENCE_GENERATOR_HPP
+#define XVEGA_SEQUENCE_GENERATOR_HPP
+
+#include "xproperty/xobserved.hpp"
+#include "xtl/xvariant.hpp"
+#include "xtl/xoptional.hpp"
+#include "nlohmann/json.hpp"
+#include "xtl/xjson.hpp"
+
+#include "../../../xvega_config.hpp"
+#include "../../../utils/serialize.hpp"
+
+namespace nl = nlohmann;
+
+namespace xv
+{
+    struct sequence_params : public xp::xobserved<sequence_params>
+    {
+        XPROPERTY(xtl::xoptional<double>, sequence_params, start);
+        XPROPERTY(xtl::xoptional<double>, sequence_params, stop);
+        XPROPERTY(xtl::xoptional<double>, sequence_params, step);
+        XPROPERTY(xtl::xoptional<std::string>, sequence_params, as);
+    };
+
+    void to_json(nl::json& j, const sequence_params& data);
+
+    struct sequence_generator : public xp::xobserved<sequence_generator>
+    {
+        XPROPERTY(xtl::xoptional<sequence_params>, sequence_generator, sequence);
+        XPROPERTY(xtl::xoptional<std::string>, sequence_generator, name);
+    };
+
+    void to_json(nl::json& j, const sequence_generator& data);
+}
+
+#endif

--- a/include/xvega/grammar/data/generator/sphere_generator.hpp
+++ b/include/xvega/grammar/data/generator/sphere_generator.hpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef XVEGA_SPHERE_GENERATOR_HPP
+#define XVEGA_SPHERE_GENERATOR_HPP
+
+#include "xproperty/xobserved.hpp"
+#include "xtl/xvariant.hpp"
+#include "xtl/xoptional.hpp"
+#include "nlohmann/json.hpp"
+#include "xtl/xjson.hpp"
+
+#include "../../../xvega_config.hpp"
+#include "../../../utils/serialize.hpp"
+
+namespace xv
+{
+    using bool_object_type = xtl::variant<bool, nl::json>;
+
+    struct sphere_generator : public xp::xobserved<sphere_generator>
+    {
+        XPROPERTY(xtl::xoptional<bool_object_type>, sphere_generator, sphere);
+        XPROPERTY(xtl::xoptional<std::string>, sphere_generator, name);
+    };
+
+    void to_json(nl::json& j, const sphere_generator& data);
+}
+
+#endif

--- a/include/xvega/grammar/marks.hpp
+++ b/include/xvega/grammar/marks.hpp
@@ -19,7 +19,7 @@ namespace xv
     struct mark : public xp::xobserved<D>
     {
         // General Mark Properties
-        XPROPERTY(xtl::xoptional<std::string>, D, type, xtl::missing<std::string>(), XEITHER_OPTIONAL("arc", "bar", "circle", "square", "tick", "line", "area", "point", "geoshape", "rule", "text", "image"));
+        XPROPERTY(xtl::xoptional<std::string>, D, type);
         XPROPERTY(xtl::xoptional<bool>, D, aria);
         XPROPERTY(xtl::xoptional<std::string>, D, description);
         XPROPERTY(xtl::xoptional<std::vector<std::string>>, D, style);
@@ -45,20 +45,20 @@ namespace xv
         XPROPERTY(xtl::xoptional<color_type>, D, color);
         XPROPERTY(xtl::xoptional<color_none_type>, D, fill);
         XPROPERTY(xtl::xoptional<color_none_type>, D, stroke);
-        XPROPERTY(xtl::xoptional<std::string>, D, blend, xtl::missing<std::string>(), XEITHER_OPTIONAL("multiply", "screen", "overlay", "darken", "lighten", "color-dodge", "color-burn", "hard-light", "soft-light", "difference", "exclusion", "hue", "saturation", "color", "luminosity"));
+        XPROPERTY(xtl::xoptional<std::string>, D, blend);
         XPROPERTY(xtl::xoptional<double>, D, opacity);
         XPROPERTY(xtl::xoptional<double>, D, fillOpacity);
         XPROPERTY(xtl::xoptional<double>, D, strokeOpacity);
-        XPROPERTY(xtl::xoptional<std::string>, D, strokeCap, xtl::missing<std::string>(), XEITHER_OPTIONAL("butt", "round", "square"));
+        XPROPERTY(xtl::xoptional<std::string>, D, strokeCap);
         XPROPERTY(xtl::xoptional<std::vector<double>>, D, strokeDash);
         XPROPERTY(xtl::xoptional<double>, D, strokeDashOffset);
-        XPROPERTY(xtl::xoptional<std::string>, D, strokeJoin, xtl::missing<std::string>(), XEITHER_OPTIONAL("miter", "round", "bevel"));
+        XPROPERTY(xtl::xoptional<std::string>, D, strokeJoin);
         XPROPERTY(xtl::xoptional<double>, D, strokeMiterLimit);
         XPROPERTY(xtl::xoptional<double>, D, strokeWidth);
 
         // Hyperlink Properties
         XPROPERTY(xtl::xoptional<std::string>, D, href);
-        XPROPERTY(xtl::xoptional<std::string>, D, cursor, xtl::missing<std::string>(), XEITHER_OPTIONAL("auto", "default", "none", "context-menu", "help", "pointer", "progress", "wait", "cell", "crosshair", "text", "vertical-text", "alias", "copy", "move", "no-drop", "not-allowed", "e-resize", "n-resize", "ne-resize", "nw-resize", "s-resize", "se-resize", "sw-resize", "w-resize", "ew-resize", "ns-resize", "nesw-resize", "nwse-resize", "col-resize", "row-resize", "all-scroll", "zoom-in", "zoom-out", "grab", "grabbing"));
+        XPROPERTY(xtl::xoptional<std::string>, D, cursor);
     
         void to_json(nl::json& j) const
         {

--- a/include/xvega/grammar/marks/mark_area.hpp
+++ b/include/xvega/grammar/marks/mark_area.hpp
@@ -16,10 +16,10 @@ namespace xv
         using base_type = mark<mark_area>;
 
         // Area Mark Properties
-        XPROPERTY(xtl::xoptional<std::string>, mark_area, align, xtl::missing<std::string>(), XEITHER_OPTIONAL("left", "right", "center"));
-        XPROPERTY(xtl::xoptional<std::string>, mark_area, baseline, xtl::missing<std::string>(), XEITHER_OPTIONAL("alphabetic", "top", "middle", "bottom", "line-top", "line-bottom"));
-        XPROPERTY(xtl::xoptional<std::string>, mark_area, orient, xtl::missing<std::string>(), XEITHER_OPTIONAL("horizontal", "vertical"));
-        XPROPERTY(xtl::xoptional<std::string>, mark_area, interpolate, xtl::missing<std::string>(), XEITHER_OPTIONAL("basis", "basis-open", "basis-closed", "bundle", "cardinal", "cardinal-open", "cardinal-closed", "catmull-rom", "linear", "linear-closed", "monotone", "natural", "step", "step-before", "step-after"));
+        XPROPERTY(xtl::xoptional<std::string>, mark_area, align);
+        XPROPERTY(xtl::xoptional<std::string>, mark_area, baseline);
+        XPROPERTY(xtl::xoptional<std::string>, mark_area, orient);
+        XPROPERTY(xtl::xoptional<std::string>, mark_area, interpolate);
         XPROPERTY(xtl::xoptional<double>, mark_area, tension);
         XPROPERTY(xtl::xoptional<bool_object_type>, mark_area, line);
         XPROPERTY(xtl::xoptional<bool_string_object_type>, mark_area, point);

--- a/include/xvega/grammar/marks/mark_bar.hpp
+++ b/include/xvega/grammar/marks/mark_bar.hpp
@@ -16,9 +16,9 @@ namespace xv
         using base_type = mark<mark_bar>;
 
         // Bar Mark Properties
-        XPROPERTY(xtl::xoptional<std::string>, mark_bar, orient, xtl::missing<std::string>(), XEITHER_OPTIONAL("horizontal", "vertical"));
-        XPROPERTY(xtl::xoptional<std::string>, mark_bar, align, xtl::missing<std::string>(), XEITHER_OPTIONAL("left", "right", "center"));
-        XPROPERTY(xtl::xoptional<std::string>, mark_bar, baseline, xtl::missing<std::string>(), XEITHER_OPTIONAL("alphabetic", "top", "middle", "bottom", "line-top", "line-bottom"));
+        XPROPERTY(xtl::xoptional<std::string>, mark_bar, orient);
+        XPROPERTY(xtl::xoptional<std::string>, mark_bar, align);
+        XPROPERTY(xtl::xoptional<std::string>, mark_bar, baseline);
         XPROPERTY(xtl::xoptional<double>, mark_bar, binSpacing);
         XPROPERTY(xtl::xoptional<double>, mark_bar, cornerRadius);
         XPROPERTY(xtl::xoptional<double>, mark_bar, cornerRadiusEnd);

--- a/include/xvega/grammar/marks/mark_image.hpp
+++ b/include/xvega/grammar/marks/mark_image.hpp
@@ -18,8 +18,8 @@ namespace xv
         // Image Mark Properties
         XPROPERTY(xtl::xoptional<any_type>, mark_image, url);
         XPROPERTY(xtl::xoptional<bool>, mark_image, aspect);
-        XPROPERTY(xtl::xoptional<std::string>, mark_image, align, xtl::missing<std::string>(), XEITHER_OPTIONAL("left", "right", "center"));
-        XPROPERTY(xtl::xoptional<std::string>, mark_image, baseline, xtl::missing<std::string>(), XEITHER_OPTIONAL("alphabetic", "top", "middle", "bottom", "line-top", "line-bottom"));
+        XPROPERTY(xtl::xoptional<std::string>, mark_image, align);
+        XPROPERTY(xtl::xoptional<std::string>, mark_image, baseline);
 
         mark_image();
 

--- a/include/xvega/grammar/marks/mark_line.hpp
+++ b/include/xvega/grammar/marks/mark_line.hpp
@@ -16,8 +16,8 @@ namespace xv
         using base_type = mark<mark_line>;
 
         // Line Mark Properties
-        XPROPERTY(xtl::xoptional<std::string>, mark_line, orient, xtl::missing<std::string>(), XEITHER_OPTIONAL("horizontal", "vertical"));
-        XPROPERTY(xtl::xoptional<std::string>, mark_line, interpolate, xtl::missing<std::string>(), XEITHER_OPTIONAL("basis", "basis-open", "basis-closed", "bundle", "cardinal", "cardinal-open", "cardinal-closed", "catmull-rom", "linear", "linear-closed", "monotone", "natural", "step", "step-before", "step-after"));
+        XPROPERTY(xtl::xoptional<std::string>, mark_line, orient);
+        XPROPERTY(xtl::xoptional<std::string>, mark_line, interpolate);
         XPROPERTY(xtl::xoptional<double>, mark_line, tension);
         XPROPERTY(xtl::xoptional<bool_string_object_type>, mark_line, point);
 

--- a/include/xvega/grammar/marks/mark_rect.hpp
+++ b/include/xvega/grammar/marks/mark_rect.hpp
@@ -16,8 +16,8 @@ namespace xv
         using base_type = mark<mark_rect>;
 
         // Rect Mark Properties
-        XPROPERTY(xtl::xoptional<std::string>, mark_rect, align, xtl::missing<std::string>(), XEITHER_OPTIONAL("left", "right", "center"));
-        XPROPERTY(xtl::xoptional<std::string>, mark_rect, baseline, xtl::missing<std::string>(), XEITHER_OPTIONAL("alphabetic", "top", "middle", "bottom", "line-top", "line-bottom"));
+        XPROPERTY(xtl::xoptional<std::string>, mark_rect, align);
+        XPROPERTY(xtl::xoptional<std::string>, mark_rect, baseline);
         XPROPERTY(xtl::xoptional<double>, mark_rect, cornerRadius);
 
         mark_rect();

--- a/include/xvega/grammar/marks/mark_text.hpp
+++ b/include/xvega/grammar/marks/mark_text.hpp
@@ -17,9 +17,9 @@ namespace xv
 
         // Text Mark Properties
         XPROPERTY(xtl::xoptional<double>, mark_text, angle);
-        XPROPERTY(xtl::xoptional<std::string>, mark_text, align, xtl::missing<std::string>(), XEITHER_OPTIONAL("left", "right", "center"));
-        XPROPERTY(xtl::xoptional<std::string>, mark_text, baseline, xtl::missing<std::string>(), XEITHER_OPTIONAL("alphabetic", "top", "middle", "bottom", "line-top", "line-bottom"));
-        XPROPERTY(xtl::xoptional<std::string>, mark_text, dir, xtl::missing<std::string>(), XEITHER_OPTIONAL("ltr", "rtl"));
+        XPROPERTY(xtl::xoptional<std::string>, mark_text, align);
+        XPROPERTY(xtl::xoptional<std::string>, mark_text, baseline);
+        XPROPERTY(xtl::xoptional<std::string>, mark_text, dir);
         XPROPERTY(xtl::xoptional<double>, mark_text, dx);
         XPROPERTY(xtl::xoptional<double>, mark_text, dy);
         XPROPERTY(xtl::xoptional<std::string>, mark_text, ellipsis);

--- a/include/xvega/grammar/marks/mark_tick.hpp
+++ b/include/xvega/grammar/marks/mark_tick.hpp
@@ -17,7 +17,7 @@ namespace xv
 
         // Tick Mark Properties
         XPROPERTY(xtl::xoptional<double>, mark_tick, cornerRadius);
-        XPROPERTY(xtl::xoptional<std::string>, mark_tick, orient, xtl::missing<std::string>(), XEITHER_OPTIONAL("horizontal", "vertical"));
+        XPROPERTY(xtl::xoptional<std::string>, mark_tick, orient);
 
         mark_tick();
 

--- a/include/xvega/grammar/marks/mark_trail.hpp
+++ b/include/xvega/grammar/marks/mark_trail.hpp
@@ -16,7 +16,7 @@ namespace xv
         using base_type = mark<mark_trail>;
 
         // Trail Mark Properties
-        XPROPERTY(xtl::xoptional<std::string>, mark_trail, orient, xtl::missing<std::string>(), XEITHER_OPTIONAL("horizontal", "vertical"));
+        XPROPERTY(xtl::xoptional<std::string>, mark_trail, orient);
 
         mark_trail();
 

--- a/include/xvega/grammar/selections.hpp
+++ b/include/xvega/grammar/selections.hpp
@@ -27,7 +27,7 @@ namespace xv
     struct selection : public xp::xobserved<D>
     {
         XPROPERTY(xtl::xoptional<std::string>, D, name);
-        XPROPERTY(xtl::xoptional<std::string>, D, type, xtl::missing<std::string>(), XEITHER_OPTIONAL("single", "multi", "interval"));
+        XPROPERTY(xtl::xoptional<std::string>, D, type);
         XPROPERTY(xtl::xoptional<clear_type>, D, clear);
         XPROPERTY(xtl::xoptional<std::string>, D, empty);
         XPROPERTY(xtl::xoptional<on_type>, D, on);

--- a/include/xvega/utils/custom_datatypes.hpp
+++ b/include/xvega/utils/custom_datatypes.hpp
@@ -21,7 +21,13 @@ namespace nl = nlohmann;
 
 namespace xv
 {
-    using data_frame = std::map<std::string, std::vector<xtl::variant<double, int, std::string>>>;
+
+    using df_type = std::map<std::string, std::vector<xtl::variant<double, int, std::string>>>;
+
+    struct data_frame : public xp::xobserved<data_frame>
+    {
+        XPROPERTY(xtl::xoptional<df_type>, data_frame, values);
+    };
 
     void to_json(nl::json& j, const data_frame& data);
 

--- a/include/xvega/utils/custom_datatypes.hpp
+++ b/include/xvega/utils/custom_datatypes.hpp
@@ -23,6 +23,8 @@ namespace xv
 {
     using data_frame = std::map<std::string, std::vector<xtl::variant<double, int, std::string>>>;
 
+    void to_json(nl::json& j, const data_frame& data);
+
     using string_none_type = xtl::variant<std::nullptr_t, std::string>;
     using bool_none_type = xtl::variant<std::nullptr_t, bool>;
     using string_num_type = xtl::variant<double, int, std::string>;
@@ -66,7 +68,7 @@ namespace xv
 
     struct TooltipContent : public xp::xobserved<TooltipContent>
     {
-        XPROPERTY(xtl::xoptional<std::string>, TooltipContent, content, xtl::missing<std::string>(), XEITHER_OPTIONAL("encoding", "data"));
+        XPROPERTY(xtl::xoptional<std::string>, TooltipContent, content);
     };
 
     void to_json(nl::json& j, const TooltipContent& data);

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -1,6 +1,21 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## XVega Tutorial\n",
+    "##### Note: The example plots here are heavily borrowed from the official Altair tutorial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Imports and Data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -24,14 +39,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_frame df;\n",
-    "df[\"project\"] = {\"a\", \"a\", \"a\", \"d\", \"e\", \"f\", \"g\"};\n",
-    "df[\"score\"]= {25, 57, 23, 19, 8, 47, 8};\n",
-    "df[\"goal\"] = {25, 47, 30, 27, 38, 19, 4};\n",
-    "df[\"origin\"] = {34, 23, 35, 21, 17, 26, 34};\n",
-    "df[\"country\"] = {\"India\", \"France\", \"France\", \"Germany\", \"India\", \"Germany\", \"France\"};\n",
-    "df[\"feedback\"] = {\"good\", \"bad\", \"bad\", \"neutral\", \"good\", \"neutral\", \"bad\"};\n",
-    "df[\"url\"] = {\"https://www.google.com/search?q=India\", \"https://www.google.com/search?q=France\", \"https://www.google.com/search?q=France\", \"https://www.google.com/search?q=Germany\", \"https://www.google.com/search?q=India\", \"https://www.google.com/search?q=Germany\", \"https://www.google.com/search?q=France\"};"
+    "auto df = url_data().url(\"https://vega.github.io/vega-datasets/data/cars.json\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Zero Dimensional Chart"
    ]
   },
   {
@@ -40,48 +55,445 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "auto ax = Axis().format(std::string(\".1\"));\n",
-    "\n",
-    "auto x_enc = X().field(\"score\").type(\"quantitative\");\n",
-    "auto y_enc = Y().field(\"goal\").type(\"quantitative\").axis(ax);\n",
-    "\n",
-    "auto s = {\"bad\", \"neutral\", \"good\"};\n",
-    "auto c = {\"#c30d24\", \"#f8a95c\", \"#1770ab\"};\n",
-    "auto scale_option = Scale().domain(s).range(c);\n",
-    "\n",
-    "auto color_enc = Color().field(\"feedback\").type(\"nominal\").scale(scale_option);\n",
-    "auto row_enc = Row().field(\"feedback\").type(\"nominal\");\n",
-    "auto size_enc = Size().field(\"origin\").type(\"quantitative\");\n",
-    "\n",
-    "auto tooltip_enc_1 = Tooltip().field(\"origin\").type(\"quantitative\");\n",
-    "auto tooltip_enc_2 = Tooltip().field(\"country\").type(\"nominal\");\n",
-    "auto t = {tooltip_enc_1, tooltip_enc_2};\n",
-    "\n",
-    "auto text_enc = Text().field(\"project\").type(\"nominal\");\n",
-    "\n",
-    "auto rule_enc = Y().field(\"goal\").type(\"quantitative\").aggregate(\"mean\");\n",
-    "\n",
-    "auto href_enc = Href().field(\"url\").type(\"nominal\");\n",
-    "\n",
-    "auto enc = Encodings().x(x_enc).y(y_enc).color(color_enc).tooltip(t).href(href_enc);\n",
-    "auto enc_2 = Encodings().text(text_enc).x(x_enc).y(y_enc);\n",
-    "auto enc_3 = Encodings().y(rule_enc);\n",
-    "auto enc_4 = Encodings().x(x_enc).y(y_enc);\n",
-    "\n",
-    "auto stop_1 = GradientStop().color(\"white\").offset(0);\n",
-    "auto stop_2 = GradientStop().color(\"green\").offset(1);\n",
-    "auto grad = LinearGradient().stops({stop_1, stop_2}).x1(1).y1(1);\n",
-    "\n",
-    "nl::json line_prop;\n",
-    "line_prop[\"color\"] = \"pink\";\n",
-    "\n",
-    "auto mc = mark_circle().size(100);\n",
-    "auto mt = mark_text().align(\"left\").baseline(\"middle\").dx(10);\n",
-    "auto mr = mark_rule().color(\"firebrick\");\n",
-    "auto ma = mark_area().line(line_prop).color(grad).interpolate(\"monotone\");\n",
-    "\n",
-    "auto fig = Chart().data(df).marks({ma, mc, mt, mr}).encodings({enc_4, enc, enc_2, enc_3}).width(300);\n",
+    "auto mp = mark_point();\n",
+    "auto fig = Chart().data(df).marks({mp});\n",
     "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. One Dimensional Chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto x_enc = X().field(\"Miles_per_Gallon\").type(\"quantitative\");\n",
+    "auto enc = Encodings().x(x_enc);\n",
+    "fig = Chart().data(df).marks({mp}).encodings({enc}).width(400);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. Two Dimensional Chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto y_enc = Y().field(\"Horsepower\").type(\"quantitative\");\n",
+    "enc = Encodings().x(x_enc).y(y_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mp}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5. Third Dimension? "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### With Categorical data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto color_enc = Color().field(\"Origin\").type(\"nominal\");\n",
+    "enc = Encodings().x(x_enc).y(y_enc).color(color_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mp}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### What if the type is changed to Quantitative i.e. Continuous values?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "color_enc = Color().field(\"Acceleration\").type(\"quantitative\");\n",
+    "enc = Encodings().x(x_enc).y(y_enc).color(color_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mp}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### What if the type is changed to Ordinal i.e. Ordered Values?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "color_enc = Color().field(\"Cylinders\").type(\"ordinal\");\n",
+    "enc = Encodings().x(x_enc).y(y_enc).color(color_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mp}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6. Binning and Aggregation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Binning with default parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto mb = mark_bar();\n",
+    "x_enc = X().field(\"Miles_per_Gallon\").type(\"quantitative\").bin(true);\n",
+    "y_enc = Y().aggregate(\"count\");\n",
+    "\n",
+    "enc = Encodings().x(x_enc).y(y_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mb}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Binning with more control"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto bin_params = Bin().maxbins(30);\n",
+    "x_enc = X().field(\"Miles_per_Gallon\").type(\"quantitative\").bin(bin_params);\n",
+    "\n",
+    "enc = Encodings().x(x_enc).y(y_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mb}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Let's add the 3rd dimension again!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "color_enc = Color().field(\"Origin\").type(\"nominal\");\n",
+    "enc = Encodings().x(x_enc).y(y_enc).color(color_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mb}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### What about separate plots?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto column_enc = Column().field(\"Origin\").type(\"nominal\");\n",
+    "\n",
+    "enc = Encodings().x(x_enc).y(y_enc).color(color_enc).column(column_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mb}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Binning in Two Dimensions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto mr = mark_rect();\n",
+    "\n",
+    "x_enc = X().field(\"Miles_per_Gallon\").type(\"quantitative\").bin(true);\n",
+    "y_enc = Y().field(\"Horsepower\").type(\"quantitative\").bin(true);\n",
+    "color_enc = Color().aggregate(\"count\");\n",
+    "\n",
+    "enc = Encodings().x(x_enc).y(y_enc).color(color_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mr}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Let's change the aggregation from counting to mean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "color_enc = Color().field(\"Weight_in_lbs\").type(\"quantitative\").aggregate(\"mean\");\n",
+    "\n",
+    "enc = Encodings().x(x_enc).y(y_enc).color(color_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mr}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7. Time Series and Layering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_enc = X().field(\"Year\").type(\"temporal\");\n",
+    "y_enc = Y().field(\"Miles_per_Gallon\").type(\"quantitative\");\n",
+    "\n",
+    "enc = Encodings().x(x_enc).y(y_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mp}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Let's plot the mean instead of all points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto ml = mark_line();\n",
+    "y_enc = Y().field(\"Miles_per_Gallon\").type(\"quantitative\").aggregate(\"mean\");\n",
+    "\n",
+    "enc = Encodings().x(x_enc).y(y_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({ml}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### We can also plot the confidence interval of the estimated mean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto ma = mark_area();\n",
+    "y_enc = Y().field(\"Miles_per_Gallon\").type(\"quantitative\").aggregate(\"ci0\");\n",
+    "auto y2_enc = Y2().field(\"Miles_per_Gallon\").aggregate(\"ci1\");\n",
+    "\n",
+    "enc = Encodings().x(x_enc).y(y_enc).y2(y2_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({ma}).encodings({enc}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Let's Adjust the Chart by configuring Opacity, adding a cleaner Y Axis Title and splitting it by Country of Origin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ma = mark_area().opacity(0.3);\n",
+    "x_enc = X().field(\"Year\").type(\"temporal\").timeUnit(\"year\");\n",
+    "\n",
+    "std::vector<std::string> title_text = {\"Miles per Gallon\"};\n",
+    "auto ax = Axis().title(title_text);\n",
+    "\n",
+    "y_enc = Y().field(\"Miles_per_Gallon\").type(\"quantitative\").aggregate(\"ci0\").axis(ax);\n",
+    "color_enc = Color().field(\"Origin\").type(\"nominal\");\n",
+    "\n",
+    "enc = Encodings().x(x_enc).y(y_enc).y2(y2_enc).color(color_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({ma}).encodings({enc}).width(800).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Let's represent the mean on top of the confidence interval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto y_enc_2 = Y().field(\"Miles_per_Gallon\").type(\"quantitative\").aggregate(\"mean\");\n",
+    "\n",
+    "auto enc_2 = Encodings().x(x_enc).y(y_enc_2).color(color_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({ma, ml}).encodings({enc, enc_2}).width(800).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 8. Sneak Peek on Selections and Interactivity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto si = selection_interval();\n",
+    "\n",
+    "x_enc = X().field(\"Miles_per_Gallon\").type(\"quantitative\");\n",
+    "y_enc = Y().field(\"Horsepower\").type(\"quantitative\");\n",
+    "color_enc = Color().field(\"Origin\").type(\"nominal\");\n",
+    "\n",
+    "enc = Encodings().x(x_enc).y(y_enc).color(color_enc);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mp}).encodings({enc}).selections({si}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Customising the Interval Selection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "std::vector<std::string> si_props = {\"y\"};\n",
+    "si = selection_interval().encodings(si_props);\n",
+    "\n",
+    "fig = Chart().data(df).marks({mp}).encodings({enc}).selections({si}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "si = selection_interval().bind(\"scales\");\n",
+    "\n",
+    "fig = Chart().data(df).marks({mp}).encodings({enc}).selections({si}).width(400).height(300);\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Note: While single and multi selections also work, it would be futile to demo them without conditions and conditions haven't been implemented as of now."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Coming Soon!\n",
+    "- Support for Conditions\n",
+    "- Support for View Compositions (Horizontal and Vertical Concatenation, etc.)\n",
+    "- Chart Configurations\n",
+    "- Transformations"
    ]
   }
  ],

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -474,6 +474,11 @@
    "source": [
     "si = selection_interval().bind(\"scales\");\n",
     "\n",
+    "auto tooltip_enc = Tooltip().field(\"Name\").type(\"nominal\");\n",
+    "auto t = {tooltip_enc};\n",
+    "\n",
+    "enc = Encodings().x(x_enc).y(y_enc).color(color_enc).tooltip(t);\n",
+    "\n",
     "fig = Chart().data(df).marks({mp}).encodings({enc}).selections({si}).width(400).height(300);\n",
     "fig"
    ]

--- a/src/grammar/data/data_format/csv_data_format.cpp
+++ b/src/grammar/data/data_format/csv_data_format.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "xvega/grammar/data/data_format/csv_data_format.hpp"
+
+namespace xv
+{
+    csv_data_format::csv_data_format()
+    {
+        type = "csv";
+    }
+
+    void csv_data_format::to_json(nl::json& j) const
+    {
+        base_type::to_json(j);
+    }
+}

--- a/src/grammar/data/data_format/dsv_data_format.cpp
+++ b/src/grammar/data/data_format/dsv_data_format.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "xvega/grammar/data/data_format/dsv_data_format.hpp"
+
+namespace xv
+{
+    dsv_data_format::dsv_data_format()
+    {
+        type = "dsv";
+    }
+
+    void dsv_data_format::to_json(nl::json& j) const
+    {
+        base_type::to_json(j);
+        serialize(j, delimiter(), "delimiter");
+    }
+}

--- a/src/grammar/data/data_format/json_data_format.cpp
+++ b/src/grammar/data/data_format/json_data_format.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "xvega/grammar/data/data_format/json_data_format.hpp"
+
+namespace xv
+{
+    json_data_format::json_data_format()
+    {
+        type = "json";
+    }
+
+    void json_data_format::to_json(nl::json& j) const
+    {
+        base_type::to_json(j);
+        serialize(j, property(), "property");
+    }
+}

--- a/src/grammar/data/data_format/topo_data_format.cpp
+++ b/src/grammar/data/data_format/topo_data_format.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "xvega/grammar/data/data_format/topo_data_format.hpp"
+
+namespace xv
+{
+    topo_data_format::topo_data_format()
+    {
+        type = "topojson";
+    }
+
+    void topo_data_format::to_json(nl::json& j) const
+    {
+        base_type::to_json(j);
+        serialize(j, feature(), "feature");
+        serialize(j, mesh(), "mesh");
+    }
+}

--- a/src/grammar/data/data_format/tsv_data_format.cpp
+++ b/src/grammar/data/data_format/tsv_data_format.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "xvega/grammar/data/data_format/tsv_data_format.hpp"
+
+namespace xv
+{
+    tsv_data_format::tsv_data_format()
+    {
+        type = "tsv";
+    }
+
+    void tsv_data_format::to_json(nl::json& j) const
+    {
+        base_type::to_json(j);
+    }
+}

--- a/src/grammar/data/data_source/inline_data.cpp
+++ b/src/grammar/data/data_source/inline_data.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "xvega/grammar/data/data_source/inline_data.hpp"
+
+namespace xv
+{
+    void to_json(nl::json& j, const inline_data& data)
+    {
+        j["values"] = data.values();
+        serialize(j, data.name(), "name");
+        serialize(j, data.format(), "format");
+    }
+}

--- a/src/grammar/data/data_source/named_data.cpp
+++ b/src/grammar/data/data_source/named_data.cpp
@@ -4,12 +4,13 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include "xvega/functions/populate_data.hpp"
+#include "xvega/grammar/data/data_source/named_data.hpp"
 
 namespace xv
 {
-    void populate_data(nl::json& json_template, const Chart& v)
+    void to_json(nl::json& j, const named_data& data)
     {
-        json_template["data"] = v.data();
-    }   
+        serialize(j, data.name(), "name");
+        serialize(j, data.format(), "format");
+    }
 }

--- a/src/grammar/data/data_source/url_data.cpp
+++ b/src/grammar/data/data_source/url_data.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "xvega/grammar/data/data_source/url_data.hpp"
+
+namespace xv
+{
+    void to_json(nl::json& j, const url_data& data)
+    {
+        serialize(j, data.url(), "url");
+        serialize(j, data.name(), "name");
+        serialize(j, data.format(), "format");
+    }
+}

--- a/src/grammar/data/generator/graticule_generator.cpp
+++ b/src/grammar/data/generator/graticule_generator.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "xvega/grammar/data/generator/graticule_generator.hpp"
+
+namespace xv
+{
+    void to_json(nl::json& j, const graticule_params& data)
+    {
+        serialize(j, data.extent(), "extent");
+        serialize(j, data.extentMajor(), "extentMajor");
+        serialize(j, data.extentMinor(), "extentMinor");
+        serialize(j, data.precision(), "precision");
+        serialize(j, data.step(), "step");
+        serialize(j, data.stepMajor(), "stepMajor");
+        serialize(j, data.stepMinor(), "stepMinor");
+    }
+
+    void to_json(nl::json& j, const graticule_generator& data)
+    {
+        serialize(j, data.graticule(), "graticule");
+        serialize(j, data.name(), "name");
+    }
+}

--- a/src/grammar/data/generator/sequence_generator.cpp
+++ b/src/grammar/data/generator/sequence_generator.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2020, QuantStack and XVega Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "xvega/grammar/data/generator/sequence_generator.hpp"
+
+namespace xv
+{
+    void to_json(nl::json& j, const sequence_params& data)
+    {
+        serialize(j, data.start(), "start");
+        serialize(j, data.stop(), "stop");
+        serialize(j, data.step(), "step");
+        serialize(j, data.as(), "as");
+    }
+
+    void to_json(nl::json& j, const sequence_generator& data)
+    {
+        serialize(j, data.sequence(), "sequence");
+        serialize(j, data.name(), "name");
+    }
+}

--- a/src/grammar/data/generator/sphere_generator.cpp
+++ b/src/grammar/data/generator/sphere_generator.cpp
@@ -4,12 +4,13 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include "xvega/functions/populate_data.hpp"
+#include "xvega/grammar/data/generator/sphere_generator.hpp"
 
 namespace xv
 {
-    void populate_data(nl::json& json_template, const Chart& v)
+    void to_json(nl::json& j, const sphere_generator& data)
     {
-        json_template["data"] = v.data();
-    }   
+        serialize(j, data.sphere(), "sphere");
+        serialize(j, data.name(), "name");
+    }
 }

--- a/src/utils/custom_datatypes.cpp
+++ b/src/utils/custom_datatypes.cpp
@@ -5,9 +5,27 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 #include "xvega/utils/custom_datatypes.hpp"
+#include <iostream>
 
 namespace xv
 {
+    void to_json(nl::json& j, const data_frame& data)
+    {
+        j["values"] = {{}};
+        int i;
+        for(auto const& x : data)
+        {
+            std::string column_name = x.first;
+            std::vector<xtl::variant<double, int, std::string>> values = x.second;
+            i = 0;
+            for(auto& k: values)
+            {
+                xtl::visit([&](auto&& each_value){j["data"]["values"][i][x.first]=each_value;}, k);
+                i++;
+            }
+        }
+    }
+
     void to_json(nl::json& j, const GradientStop& data)
     {
         serialize(j, data.color(), "color");

--- a/src/utils/custom_datatypes.cpp
+++ b/src/utils/custom_datatypes.cpp
@@ -13,14 +13,14 @@ namespace xv
     {
         j["values"] = {{}};
         int i;
-        for(auto const& x : data)
+        for(auto const& x : data.values().value())
         {
             std::string column_name = x.first;
             std::vector<xtl::variant<double, int, std::string>> values = x.second;
             i = 0;
             for(auto& k: values)
             {
-                xtl::visit([&](auto&& each_value){j["data"]["values"][i][x.first]=each_value;}, k);
+                xtl::visit([&](auto&& each_value){j["values"][i][x.first]=each_value;}, k);
                 i++;
             }
         }


### PR DESCRIPTION
This also breaks the support for `data_frame` i.e. 
`std::map<std::string, std::vector<xtl::variant<double, int, std::string>>>`.
But we can tackle it in a different PR.

This PR also includes a detailed nice tutorial in a Jupyter Notebook.